### PR TITLE
Add optional attribute 'required' for parameters/parameter

### DIFF
--- a/ra/next/ra-api.ng
+++ b/ra/next/ra-api.ng
@@ -21,6 +21,9 @@
 			<optional>
 				<attribute name="unique"> <ref name="boolean-values" /> </attribute>
 			</optional>
+			<optional>
+				<attribute name="required"> <ref name="boolean-values" /> </attribute>
+			</optional>
 
 			<oneOrMore> <element name="longdesc">
 				<ref name="description" />

--- a/ra/next/ra-metadata-example.xml
+++ b/ra/next/ra-metadata-example.xml
@@ -18,7 +18,7 @@
      of unique parameters.
  -->
 
-<parameter name="Mountpoint" unique="1">
+<parameter name="Mountpoint" unique="1" required="0">
 <!-- This is the long, helpful description of what the parameter is all
      about. A user interface might display it to the user if he asks for
      elaborate help with an option, and it would obviously also provide


### PR DESCRIPTION
This attribute is already heavily used so it should be in standard. It
looks very useful but often it would be preferable to have an option
to enter more complex queries (e.g enter X or Y)