### PR TITLE
Add optional attribute 'replaced-by' for parameters/parameter

### DIFF
--- a/ra/next/ra-api.ng
+++ b/ra/next/ra-api.ng
@@ -24,6 +24,9 @@
 			<optional>
 				<attribute name="required"> <ref name="boolean-values" /> </attribute>
 			</optional>
+			<optional>
+				<attribute name="replaced-by"> <text /> </attribute>
+			</optional>
 
 			<oneOrMore> <element name="longdesc">
 				<ref name="description" />

--- a/ra/next/ra-metadata-example.xml
+++ b/ra/next/ra-metadata-example.xml
@@ -41,7 +41,7 @@ mounted.  Please make sure it exists.
 
 </parameter>
 
-<parameter name="Device" unique="1">
+<parameter name="Device" unique="1" replaced-by="new-device">
 <longdesc lang="en">
 When mounting a filesystem on a specific mountpoint, you have to specify which
 device should be mounted; this will usually be similiar to /dev/sda1 or


### PR DESCRIPTION
This attribute allows us to mark a parameter as obsolete one and points us to the replacement. It is required for renaming (= standardizing) names of parameters, so additional tools (e.g. pcs) can properly ignore those parameters if required.

It might be possible that there parameter is completely discarded but that did not happend yet. Currently, similar attribute is used in the fence agents only.
