### PR TITLE
Improve wording of the RA API

### DIFF
--- a/ra/next/resource-agent-api.md
+++ b/ra/next/resource-agent-api.md
@@ -46,59 +46,68 @@ copy of the license can be found at http://www.gnu.org/licenses/fdl.txt.
 
 ## Terms used in this document
 
-### "Resource"
+### Resource
 
-A single physical or logical entity that provides a service to clients or
-other resources. For example, a resource can be a single disk volume, a
-particular network address, or an application such as a web server. A resource
-is generally available for use over time on two or more nodes in a cluster,
-although it usually can be allocated to only one node at any given time.
+A _resource_, also known as a _resource instance_, is a logical entity that
+provides a particular computer-hosted service. Examples of resources include a
+disk volume, a network address, a web server, or a virtual machine.
 
-Resources are identified by a name that must be unique to the particular
-resource type. This is any name chosen by the administrator to identify
-the resource instance and passed to the RA as a special environment
-variable.
+### Cluster
 
-A resource may also have instance parameters which provide additional
-information required for Resource Agent to control the resource.
+A _cluster_ is a collection of one or more computers under common
+administration running a set of resources.
 
+### Resource Manager
 
-### "Resource types"
+A _resource manager_ (RM), also known as a _cluster resource manager_ (CRM),
+is software that manages resources in a cluster.
 
-A resource type represents a set of resources which share a common set of
-instance parameters and a common set of actions which can be performed on
-resource of the given type.
+### Resource Type
 
-The resource type name is chosen by the provider of the RA.
+A _resource type_, also known as a _resource class_, is a name indicating the
+service provided by a resource. This name should be suitable for use as a file
+name.
 
+### Resource Agent
 
-### "Resource agent"
+A _resource agent_ (RA) is a software application implementing the RA API for a
+particular resource type. An RA allows a resource manager to perform specific
+mangement tasks for resource instances.
 
-A RA provides the actions ("member functions") for a given type of
-resources; by providing the RA with the instance parameters, it is used
-to control a specific resource.
+### Resource Agent Provider
 
-They are usually implemented as shell scripts, but the API described here does
-not require this.
+A _resource agent provider_ is an entity supplying one or more resource agents
+for installation on cluster hosts. Each provider should have a unique name
+suitable for use as a file system directory name.
 
-Although this is somewhat similar to LSB init scripts, there are some
-differences explained below. 
+A provider may choose to supply multiple, separate collections of resource
+agents. In this case, each collection should have a unique name, and _provider_
+may refer either to the entity as a whole, or to an individual collection.
 
+Currently, there is no central registry for provider names. Providers should
+choose names that do not appear to be already in use for publicly available
+resource agents.
 
-### "Instance parameters"
+Each provider also chooses the resource type names used for the resource agents
+it provides. These do not need to be unique across providers.
 
-Instance parameters are the attributes which describe a given resource
-instance. It is recommended that the implementor minimize the set of
-instance parameters.
+### Resource Name 
 
-The meta data allows the RA to flag one or more instance parameters as
-`unique`. This is a hint to the RM or higher level configuration tools
-that the combination of these parameters must be unique to the given
-resource type.
+A _resource name_ is a unique identifier chosen by the cluster administrator
+to identify a particular resource instance.
 
-An instance parameter has a given name and value. They are both case
-sensitive and must satisfy the requirements of POSIX environment
-name/value combinations.
+### Resource Parameters
+
+_Resource parameters_, also known as _instance parameters_, are attributes
+describing a particular resource instance. Each parameter has a name and a
+value, which must satisfy the requirements of POSIX environment variable names
+and values.
+
+The resource agent defines the names, meaning, and allowed values of parameters
+available for its resource type.
+
+The cluster administrator specifies the particular parameters used for each
+resource instance.
 
 
 ## API

--- a/ra/next/resource-agent-api.md
+++ b/ra/next/resource-agent-api.md
@@ -1,8 +1,13 @@
+**DRAFT - DRAFT - DRAFT**
+
+**JOIN THE developers@clusterlabs.org MAILING LIST AND FOLLOW PULL REQUESTS
+AT https://github.com/ClusterLabs/OCF-spec/ TO DISCUSS CHANGES**
+
 # Open Clustering Framework Resource Agent API
 
 Editor: Lars Marowsky-Brée <lmb@suse.de>
 
-URL: http://www.opencf.org/standards/resource-agent-api.html
+URL: https://github.com/ClusterLabs/OCF-spec/blob/master/ra/next/resource-agent-api.md
 
 ## Abstract
 
@@ -34,9 +39,14 @@ logging et cetera, as these are NOT specific to RA and are defined in the
 respective standards.
 
 
-### API version described
+## Status of This Memo
 
-This document currently describes version 1.0 of the API. 
+This is an Open Cluster Framework (OCF) document produced by ClusterLabs
+<https://clusterlabs.org>.
+
+This document describes proposed extensions to the OCF RA API, which may be
+incorporated into future versions of the standard. It has not been adopted
+as a standard, and should be considered for discussion purposes only.
 
 
 ## Copyright Notice

--- a/ra/next/resource-agent-api.md
+++ b/ra/next/resource-agent-api.md
@@ -502,25 +502,57 @@ function as both an LSB-compliant init script and a cluster-aware RA.
 RAs may use helper functions defined for LSB init scripts.
 
 
-## RA meta data
+## Resource Agent Meta-Data
 
 ### Format
 
-The API has the following requirements which are not fulfilled by the
-LSB way of embedding meta data into the beginning of the init scripts:
+While the LSB uses shell script comments at the beginning of init scripts to
+provide meta-data, OCF RA meta-data is described using XML so that the
+meta-data can be:
 
-- Independent of the language the RA is actually written in,
+- Independent of the language the RA itself is written in,
 - Extensible,
-- Structured,
+- Structured, and
 - Easy to parse from a variety of languages.
 
-This is why the API uses simple XML to describe the RA meta data. The
-DTD for this API can be found at [this location](http://www.opencf.org/standards/ra-api-1.dtd).
+RA meta-data shall conform to the XML schema formally described at
+<https://github.com/ClusterLabs/OCF-spec/blob/master/ra/next/ra-api.rng>.
+
+### Example
+
+An example of a valid meta-data output is provided at
+<https://github.com/ClusterLabs/OCF-spec/blob/master/ra/next/ra-metadata-example.xml>.
 
 ### Semantics
 
-An example of a valid meta data output is provided in
-`ra-metadata-example.xml`.
+Certain meta-data XML elements warrant further explanation:
+
+- `resource-agent`: The optional `version` attribute should describe the
+  version of the agent itself.
+
+- `version`: This is the version of the OCF RA standard with which the RA
+  claims compatibility.
+
+- `longdesc` and `shortdesc`: These are hints to tools describing the purpose
+  of the agent. They may contain any XML, but it is strongly recommended to
+  limit the content to a text string.
+
+- `parameter`:
+    - `unique` attribute: This is a hint to RMs and other tools that the
+      combination of all parameters marked `unique` must be unique to the resource
+      type. That is, no two resource instances of the same resource type may have
+      the same combination of `unique` parameters.
+    - `required` attribute: This is a hint to RMs and other tools that every
+      resource instance of this resource type must specify a value for this
+      parameter.
+    - `longdesc` and `shortdesc`: The same guidance applies as described above
+      when these tags appear under `resource-agent`.
+
+- `action`: Resource agents should advertise each action they support,
+  including all mandatory actions, with an `action` element.
+    - `timeout`: This is a hint to RMs and other tools that every resource
+      instance of this resource type should specify a timeout equal to or greater
+      than this value.
 
 ## To-do list
 

--- a/ra/next/resource-agent-api.md
+++ b/ra/next/resource-agent-api.md
@@ -540,13 +540,6 @@ Certain meta-data XML elements warrant further explanation:
       instance of this resource type should specify a timeout equal to or greater
       than this value.
 
-## To-do list
-
-- Move the terminology definitions out into a separate document
-  common to all OCF work.
-- An interface where the RA asynchronously informs the RM of
-  failures is planned but not defined yet. 
-
 ## Contributors
 
 - James Bottomley <James.Bottomley@steeleye.com>

--- a/ra/next/resource-agent-api.md
+++ b/ra/next/resource-agent-api.md
@@ -128,29 +128,69 @@ zero. The minor number can be used by both sides to see whether a
 certain additional feature is supported by the other party.
 
 
-### Paths
+### The Resource Agent Directory
 
-The Resource Agents are located in subdirectories under
-`/usr/ocf/resource.d`.
+Resource agents are executable files that must be made available beneath a
+common location on a host's file system, referred to as the _resource agent
+directory_.
 
-The subdirectories allow the installation of multiple RAs for the same
-type, but from different vendors or package versions.
+In the 1.0 version of this standard, the only acceptable location of this
+directory was `/usr/ocf/resource.d`. However, in practice, installations
+typically used the nonconforming location `/usr/lib/ocf/resource.d`.
 
-The filename within the directories equals the resource type name
-provided by the RA and may be a link to the real location.
+For strict compatibility with the standard, resource agents should be installed
+in the 1.0 location, and resource managers should look for agents there.
 
-Example directory structure:
+For widest compatibility, resource agents and resource managers should allow
+the installer to choose the location of the directory, which should have a
+reasonable default, and should be identical for all resource agents and
+resource managers installed on a particular host. Resource managers may also
+choose to search multiple locations.
 
-    FailSafe -> FailSafe-1.1.0/
-    FailSafe-1.0.4/
-    FailSafe-1.1.0/
-    heartbeat -> heartbeat-1.1.2/
-    heartbeat-1.1.2/
-    heartbeat-1.1.2/IPAddr
-    heartbeat-1.1.2/IP -> IPAddr
 
-How the RM choses an agent for a specific resource type name from the
-available set is implementation specific.
+### The Resource Agent Directory Tree
+
+Each provider shall install its resource agents in a subdirectory of the
+resource agent directory, using the provider's name. This allows installation
+of multiple resource agents for the same type, but from different suppliers or
+package versions.
+
+Each resource agent should be installed as a file within the provider
+subdirectory, named according to the resource type.
+
+The provider subdirectory and resource agent file may be links to the actual
+locations.
+
+A simple example of a resource agent directory tree containing a single
+provider `acme` that provides resource agents `widget` and `gadget`:
+
+    acme/
+        acme/widget
+        acme/gadget
+
+Another example where multiple versions of acme's agents are installed:
+
+    acme -> acme-2.0/
+    acme-1.0/
+        acme-1.0/widget
+        acme-1.0/gadget
+    acme-2.0/
+        acme-2.0/widget
+        acme-2.0/gadget
+
+An example with two providers, an agent available from two providers, and an
+agent available under multiple names from the same provider:
+
+    acme/
+        acme/widget
+        acme/gadget
+    betterco/
+        betterco/widget
+        betterco/IP -> IPAddr
+        betterco/IPAddr
+
+Resource managers may choose an agent for a specific resource type name from
+the available set in any manner they choose.
 
 
 ### Execution syntax

--- a/ra/next/resource-agent-api.md
+++ b/ra/next/resource-agent-api.md
@@ -4,16 +4,6 @@ Editor: Lars Marowsky-Brée <lmb@suse.de>
 
 URL: http://www.opencf.org/standards/resource-agent-api.html
 
-## License
-
-    Copyright (c) 2002 Lars Marowsky-Brée.
-
-    Permission is granted to copy, distribute and/or modify this document
-    under the terms of the GNU Free Documentation License, Version 1.2 or
-    any later version published by the Free Software Foundation; with no
-    Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts. A
-    copy of the license can be found at http://www.gnu.org/licenses/fdl.txt.
-
 ## Abstract
 
 Resource Agents (RA) are the middle layer between the Resource Manager
@@ -47,6 +37,17 @@ respective standards.
 ### API version described
 
 This document currently describes version 1.0 of the API. 
+
+
+## Copyright Notice
+
+Copyright 2002,2018 Lars Marowsky-Brée
+
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.2 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts. A
+copy of the license can be found at http://www.gnu.org/licenses/fdl.txt.
 
 
 ## Terms used in this document

--- a/ra/next/resource-agent-api.md
+++ b/ra/next/resource-agent-api.md
@@ -64,9 +64,8 @@ is software that manages resources in a cluster.
 
 ### Resource Type
 
-A _resource type_, also known as a _resource class_, is a name indicating the
-service provided by a resource. This name should be suitable for use as a file
-name.
+A _resource type_ is a name indicating the service provided by a resource. This
+name should be suitable for use as a file name.
 
 ### Resource Agent
 

--- a/ra/next/resource-agent-api.md
+++ b/ra/next/resource-agent-api.md
@@ -9,34 +9,18 @@ Editor: Lars Marowsky-Brée <lmb@suse.de>
 
 URL: https://github.com/ClusterLabs/OCF-spec/blob/master/ra/next/resource-agent-api.md
 
+
 ## Abstract
 
-Resource Agents (RA) are the middle layer between the Resource Manager
-(RM) and the actual resources being managed. They aim to integrate the
-resource type with the RM without any modifications to the actual
-resource provider itself, by encapsulating it carefully and providing
-generic methods (actions) to operate on them.
+The Open Clustering Framework Resource Agent (RA) API provides an abstraction
+layer between diverse, computer-hosted resources and diverse types of software
+managing such resources in a clustered environment.
 
-The RAs are obviously very specific to the resource type they operate
-on, however there is no reason why they should be specific to a
-particular RM.
-
-The API described in this document should be general enough that a
-compliant Resource Agent can be used by all existing resource managers /
-switch-over systems who chose to implement this API either exclusively
-or in addition to their existing one.
-
-
-### Scope
-
-This document describes a common API for the RM to call the RAs so the
-pool of available RAs can be shared by the different clustering
-solutions.
-
-It does NOT define any libraries or helper functions which RAs might share
-with regard to common functionality like external command execution, cluster
-logging et cetera, as these are NOT specific to RA and are defined in the
-respective standards.
+The RA API allows resources to be managed without any modification to the
+actual resource providers, by providing a standardized interface to common
+management tasks. It also allows (but does not require) RAs to be designed
+without consideration of specific software that might invoke them, and thus
+shared by any such software.
 
 
 ## Status of This Memo
@@ -502,3 +486,4 @@ An example of a valid meta data output is provided in
 - Lars Marowsky-Brée <lmb@suse.de>
 - Alan Robertson <alanr@unix.sh>
 - Yixiong Zou <yixiong.zou@intel.com> 
+- Ken Gaillot <kgaillot@redhat.com>

--- a/ra/next/resource-agent-api.md
+++ b/ra/next/resource-agent-api.md
@@ -423,14 +423,17 @@ It is recommended that if a requested level is not implemented,
 the RA should perform the next lower level supported.
 
 
-### Exit status codes
+### Exit Status Codes
 
-These exit status codes are the ones documented in the LSB 1.1.0
-specification, with additional explanations of how they shall be used by
-RAs. In general, all non-zero status codes shall indicate failure in
-accordance to the best current practices.
+These exit status codes are identical to those documented in the LSB 5.0 Core
+specification for non-status "Init Script Actions"
+<https://refspecs.linuxfoundation.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/iniscrptact.html>,
+with additional explanations of how they shall be used by RAs.
 
-#### All operations
+Non-zero status codes are referred to in this document as errors, however RA
+developers should keep in mind that RMs decide whether a status code is a
+failure or not (for example, if a particular error is the expected situation,
+it may not be considered a failure).
 
 - `0`
 
@@ -439,7 +442,7 @@ accordance to the best current practices.
 - `1`
 
     Generic or unspecified error (current practice)
-    The "monitor" operation shall return this for a crashed, hung or
+    The "monitor" action shall return this for a crashed, hung or
     otherwise non-functional resource.
 
 - `2`
@@ -451,7 +454,8 @@ accordance to the best current practices.
 
 - `3`
 
-    Unimplemented feature (for example, "reload")
+    Unimplemented feature
+    RAs should return this for unsupported actions (for example, "reload").
 
 - `4`
 

--- a/ra/next/resource-agent-api.md
+++ b/ra/next/resource-agent-api.md
@@ -494,13 +494,12 @@ it may not be considered a failure).
 
     Reserved
 
+
 ## Relation to the LSB
 
-It is required that the current LSB spec is fully supported by the system.
-
-The API tries to make it possible to have RA function both as a normal LSB
-init script and a cluster-aware RA, but this is not required functionality.
-The RAs could however use the helper functions defined for LSB init scripts.
+The RA API aims to make it possible for (but does not require) an RA to
+function as both an LSB-compliant init script and a cluster-aware RA.
+RAs may use helper functions defined for LSB init scripts.
 
 
 ## RA meta data


### PR DESCRIPTION
This has two goals:
* Reword sections of the RA API to clarify the intent
* Incorporate and document a few uncontroversial extensions already in common usage

Highlights:
* Document the discrepancy between the 1.0 standard OCF root directory (/usr/ocf) and the one commonly used in practice (/usr/lib/ocf), modifying the standard to distinguish between strict compatibility (the 1.0 location only) and wider compatibility (configurable location).
* Update referenced URLs.
* Document meta-data more thoroughly, including the proposed "required" parameter attribute.